### PR TITLE
docs(introduction): replace the image name 'nginx' with 'nginx:alpine'

### DIFF
--- a/introduction/101.md
+++ b/introduction/101.md
@@ -142,7 +142,7 @@ spec:
         run: nginx-app
     spec:
       containers:
-      - image: nginx
+      - image: nginx:alpine
         name: nginx-app
         ports:
         - containerPort: 80


### PR DESCRIPTION
I used the deployment file mentioned in the document (introduction/101.md), but the pod's status is always "ContainerCreating". Then I changed the image name to 'nginx:alpine', and the pod was running.

![image](https://github.com/xuruidong/kubernetes-handbook/assets/20812895/a8b0ae41-35bd-428c-b15c-50870c1f63e3)
